### PR TITLE
feat: add GitHub Actions CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,57 @@
+name: CD - dbt build on merge to main
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'olist_dbt/**'
+      - 'requirements.txt'
+      - '.github/workflows/cd.yml'
+
+jobs:
+  dbt-build:
+    name: Deploy dbt models to prod
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Create dbt profiles directory
+        run: mkdir -p ~/.dbt
+
+      - name: Write dbt profiles.yml
+        run: |
+          cat > ~/.dbt/profiles.yml << 'PROFILE'
+          olist_dbt:
+            target: prod
+            outputs:
+              prod:
+                type: bigquery
+                method: service-account-json
+                project: ${{ secrets.GCP_PROJECT_ID }}
+                dataset: prod
+                threads: 4
+                location: us-central1
+                timeout_seconds: 300
+                keyfile_json: ${{ secrets.GCP_SA_KEY }}
+          PROFILE
+
+      - name: Run dbt build
+        working-directory: olist_dbt
+        run: dbt build --target prod --profiles-dir ~/.dbt


### PR DESCRIPTION
Adds a GitHub Actions CD workflow that runs dbt build on every merge to main. Keeps prod BigQuery datasets in sync with the latest approved model state.